### PR TITLE
Tie interface constants to type.

### DIFF
--- a/src/Data/Crypto/Encryption.idr
+++ b/src/Data/Crypto/Encryption.idr
@@ -6,24 +6,22 @@ import Data.Crypto.Util
 %default total
 %access public export
 
-interface Cipher c where
-  bitsPerChunk : Nat
+interface Cipher c (bitsPerChunk : Nat) | c where
 
-interface Cipher e => Encrypter e where
+interface Cipher e bitsPerChunk => Encrypter e (bitsPerChunk : Nat) | e where
   encryptMessage : e -> List (Bits bitsPerChunk) -> List (Bits bitsPerChunk)
 
-interface Cipher d => Decrypter d where
+interface Cipher d bitsPerChunk => Decrypter d (bitsPerChunk : Nat) | d where
   decryptMessage : d -> List (Bits bitsPerChunk) -> List (Bits bitsPerChunk)
 
--- TODO this should be solved by #3936
-{-
-encrypt : (Encrypter c, Serializable pt, Serializable ct) => c -> pt -> ct
+encrypt : (Encrypter c _, Serializable pt, Serializable ct) => c -> pt -> ct
 encrypt cipher = decode . encryptMessage cipher . encode
 
-decrypt : (Decrypter c, Serializable pt, Serializable ct) => c -> pt -> ct
+decrypt : (Decrypter c _, Serializable pt, Serializable ct) => c -> pt -> ct
 decrypt cipher = decode . decryptMessage cipher . encode
--}
 
-interface (Encrypter c, Decrypter c) => SymmetricCipher c where
+interface (Encrypter c bitsPerChunk, Decrypter c bitsPerChunk) =>
+  SymmetricCipher c (bitsPerChunk : Nat) | c where
 
-interface (Encrypter p, Decrypter v) => AsymmetricCipher p v where
+interface (Encrypter p pb, Decrypter v vb) =>
+  AsymmetricCipher p v (pb : Nat) (vb : Nat) | p, v where

--- a/src/Data/Crypto/Encryption/Block.idr
+++ b/src/Data/Crypto/Encryption/Block.idr
@@ -9,10 +9,9 @@ import Data.Crypto.Encryption
 
 ||| for a block cypher, you only need to provide functions to encrypt/decrypt a
 ||| single block.
+-- TODO: Use `Maybe Nat` for `maximumBlocks`.
 public export
-interface BlockCipher k where
-  bitsPerBlock : Nat
-  maximumBlocks : Nat
+interface BlockCipher k (bitsPerBlock : Nat) (maximumBlocks : Nat) | k where
   encryptBlock : k -> Bits bitsPerBlock -> Bits bitsPerBlock
   decryptBlock : k -> Bits bitsPerBlock -> Bits bitsPerBlock
   -- blockTranslation : k -> Iso b b
@@ -21,26 +20,23 @@ interface BlockCipher k where
 ||| The encryption mode specifies how to apply a block cipher to multiple blocks
 public export
 interface EncryptionMode (em : Nat -> Type) where
-  encryptBlocks : BlockCipher k
+  encryptBlocks : BlockCipher k bitsPerBlock mb
                   => k -> em bitsPerBlock -> List (Bits bitsPerBlock)
                   -> List (Bits bitsPerBlock)
-  decryptBlocks : BlockCipher k
+  decryptBlocks : BlockCipher k bitsPerBlock mb
                   => k -> em bitsPerBlock -> List (Bits bitsPerBlock)
                   -> List (Bits bitsPerBlock)
 
-{-
-implementation (BlockCipher bc, EncryptionMode em) =>
-         Cipher (bc, em bitsPerBlock) where
-  bitsPerChunk = bitsPerBlock
+implementation (BlockCipher bc bitsPerBlock _, EncryptionMode em) =>
+         Cipher (bc, em bitsPerBlock) bitsPerBlock where
 
-implementation (BlockCipher bc, EncryptionMode em) =>
-         Encrypter (bc, em bitsPerBlock) where
+implementation (BlockCipher bc bitsPerBlock _, EncryptionMode em) =>
+         Encrypter (bc, em bitsPerBlock) bitsPerBlock where
   encryptMessage = uncurry encryptBlocks
 
-implementation (BlockCipher bc, EncryptionMode em) =>
-         Decrypter (bc, em bitsPerBlock) where
+implementation (BlockCipher bc bitsPerBlock _, EncryptionMode em) =>
+         Decrypter (bc, em bitsPerBlock) bitsPerBlock where
   decryptMessage = uncurry decryptBlocks
 
-implementation (BlockCipher bc, EncryptionMode em) =>
-         SymmetricCipher (bc, em bitsPerBlock) where
--}
+implementation (BlockCipher bc bitsPerBlock _, EncryptionMode em) =>
+         SymmetricCipher (bc, em bitsPerBlock) bitsPerBlock where

--- a/src/Data/Crypto/Encryption/Block/DEA.idr
+++ b/src/Data/Crypto/Encryption/Block/DEA.idr
@@ -63,9 +63,9 @@ E = selectBits (offByOne [32,  1,  2,  3,  4,  5,
 P : Bits 32 -> Bits 32
 P = selectBits (offByOne [16,  7, 20, 21,
                           29, 12, 28, 17,
-                          1, 15, 23, 26,
-                          5, 18, 31, 10,
-                          2,  8, 24, 14,
+                           1, 15, 23, 26,
+                           5, 18, 31, 10,
+                           2,  8, 24, 14,
                           32, 27,  3,  9,
                           19, 13, 30,  6,
                           22, 11,  4, 25])
@@ -161,9 +161,7 @@ KS key = map PC2
                           [1, 1, 2, 2, 2, 2, 2, 2, 1, 2, 2, 2, 2, 2, 2, 1]))
 
 
-implementation BlockCipher DataEncryptionAlgorithm where
-  bitsPerBlock = 64
-  maximumBlocks = 0
+implementation BlockCipher DataEncryptionAlgorithm 64 0 where
   encryptBlock (DEA key) block = centralDEA block (KS key)
   decryptBlock (DEA key) block = centralDEA block (reverse (KS key))
 -}

--- a/src/Data/Crypto/Encryption/Stream/ARC4.idr
+++ b/src/Data/Crypto/Encryption/Stream/ARC4.idr
@@ -1,6 +1,7 @@
 module Data.Crypto.Encryption.Stream.ARC4
 
 import Control.Monad.State
+import Data.Bits
 import Data.Fin
 import Data.Vect
 
@@ -52,10 +53,7 @@ PGRA i j S = let newI = i + 1
                       (modToBits (index (cast (index (cast newI) newS + index (cast newJ) newS)) newS))
                       (PGRA newI newJ newS)
 
-implementation Cipher (AllegedRivestCipher4 n) where
-  bitsPerChunk = 8
+implementation Cipher (AllegedRivestCipher4 n) 8 where
 
-{-
-implementation StreamCipher (AllegedRivestCipher4 n) where
+implementation StreamCipher (AllegedRivestCipher4 n) 8 where
   generateKeystream (ARC4 key) = PGRA 0 0 (KSA key)
--}


### PR DESCRIPTION
Use a multiple-paratameter-typeclass/fundep style so that the constants in
various interfaces are correctly associated with their type.